### PR TITLE
feat: add ignore properties field to allow for ignoring fields

### DIFF
--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -134,20 +134,6 @@ export async function scanUntranslatedText(
         }
       });
 
-    sourceFile
-      .getDescendantsOfKind(ts.SyntaxKind.PropertyAssignment)
-      .forEach((item) => {
-        if (['title', 'label', 'description'].includes(item.getName())) {
-          const initializer = item.getInitializer();
-          if (
-            initializer &&
-            initializer.getKind() === ts.SyntaxKind.StringLiteral
-          ) {
-            appendRes(initializer);
-          }
-        }
-      });
-
     // find object like: <div title="fooo" />
     sourceFile
       .getDescendantsOfKind(ts.SyntaxKind.JsxAttribute)


### PR DESCRIPTION
there are some default behavior for scanning things like { title: 'foo' }, im adding this option to have a choice to ignore these options. 